### PR TITLE
web: add list of users that can deploy

### DIFF
--- a/qvet-web/src/hooks/useTeamMembers.ts
+++ b/qvet-web/src/hooks/useTeamMembers.ts
@@ -1,0 +1,26 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import useOctokit from "src/hooks/useOctokit";
+import { getTeamMembers } from "src/queries";
+import { Octokit } from "octokit";
+import useConfig from "./useConfig";
+import { Config } from "src/utils/config";
+
+export function teamMembersQuery(
+  octokit: Octokit | null,
+  config: UseQueryResult<Config>,
+) {
+  return {
+    queryKey: ["getTeamMembers", { team: config.data }],
+    queryFn: () => {
+      const users = config.data!.team ? getTeamMembers(octokit!, config.data!.team) : [];
+      return users
+    },
+    enabled: !!octokit && !!config.data,
+  };
+}
+
+export default function useTeamMembers() {
+  const octokit = useOctokit();
+  const config = useConfig();
+  return useQuery(teamMembersQuery(octokit, config));
+}

--- a/qvet-web/src/octokitHelpers.ts
+++ b/qvet-web/src/octokitHelpers.ts
@@ -5,6 +5,11 @@ export interface OwnerRepo {
   repo: string;
 }
 
+export interface Team {
+  org: string;
+  team_slug: string;
+}
+
 export type Commit = components["schemas"]["commit"];
 export type CommitComparison = components["schemas"]["commit-comparison"];
 export type Status = components["schemas"]["status"];

--- a/qvet-web/src/queries/index.ts
+++ b/qvet-web/src/queries/index.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "octokit";
 import { ResponseHeaders } from "@octokit/types";
-import { OwnerRepo, Status } from "src/octokitHelpers";
+import { OwnerRepo, Status, User, Team } from "src/octokitHelpers";
 import { UpdateState, stateDisplay } from "src/utils/status";
 
 export const STATUS_CONTEXT_EMBARGO_PREFIX = "qvet/embargo/";
@@ -80,3 +80,13 @@ export async function setCommitStatus(
   });
   return data;
 }
+
+
+export async function getTeamMembers(
+  octokit: Octokit,
+  team: Team,
+): Promise<Array<User>> {
+  const { data } = await octokit.rest.teams.listMembersInOrg({...team});
+  return data;
+}
+

--- a/qvet-web/src/utils/config.ts
+++ b/qvet-web/src/utils/config.ts
@@ -83,12 +83,23 @@ const SCHEMA_RELEASE = {
   additionalProperties: false,
 };
 
+const SCHEMA_TEAM = {
+  type: "object",
+  properties: {
+    org: { type: "string", maxLength: 128 },
+    team_slug: { type: "string", maxLength: 128 },
+  },
+  required: ["org", "team_slug"],
+  additionalProperties: false,
+};
+
 const SCHEMA = {
   type: "object",
   properties: {
     action: SCHEMA_ACTION_LOOKUP,
     commit: SCHEMA_COMMIT,
     release: SCHEMA_RELEASE,
+    team: SCHEMA_TEAM,
   },
   required: [],
   additionalProperties: false,
@@ -107,6 +118,7 @@ export interface Config {
   release: {
     identifiers: Array<Identifier>;
   };
+  team: Team | null;
 }
 
 export interface ActionLink {
@@ -115,6 +127,11 @@ export interface ActionLink {
   url: string;
 }
 export type Action = ActionLink;
+
+export interface Team {
+  org: string;
+  team_slug: string;
+}
 
 export interface IdentifierTag {
   type: "tag";
@@ -134,6 +151,7 @@ export function parseConfigFile(configFile: string): ParseConfigFileResult {
 
   const errorsText = valid ? null : ajv.errorsText(validator.errors);
   const config = valid ? standardiseConfig(raw) : standardiseConfig({});
+  console.log(config);
 
   return { config, errorsText };
 }
@@ -157,5 +175,6 @@ function standardiseConfig(raw: any): Config {
         },
       ],
     },
+    team: raw.team ?? null,
   };
 }


### PR DESCRIPTION
This PR displays a set of three (or less) users that can deploy code to production in the UI. These users are randomly selected from the list of users that belong to a team specified in the configuration file, from which users with a commit to be deployed have been subtracted.