### PR TITLE
Configurable base branch

### DIFF
--- a/qvet-web/src/components/CommitSummary.tsx
+++ b/qvet-web/src/components/CommitSummary.tsx
@@ -27,6 +27,9 @@ export default function CommitSummary({
 
   const authorLogins = config.commit.ignore.authors;
   const merges = config.commit.ignore.merges;
+  const base_branch = config.commit.base
+    ? config.commit.base
+    : repo.default_branch;
   const developerCommits = comparison.commits.filter((commit) => {
     // Is a merge (and we don't want merges)
     if (merges && commit.parents.length > 1) {
@@ -96,7 +99,7 @@ export default function CommitSummary({
       <CommitTable commits={visibleCommits} />
       <Typography variant="caption">
         Showing {developerCommits.length} undeployed commits on{" "}
-        <code>{repo.default_branch}</code> (view the{" "}
+        <code>{base_branch}</code> (view the{" "}
         {
           <Link target="_blank" to={comparison.html_url}>
             Github comparison

--- a/qvet-web/src/components/Comparison.tsx
+++ b/qvet-web/src/components/Comparison.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import CommitSummary from "src/components/CommitSummary";
 import useOctokit from "src/hooks/useOctokit";
 import useConfig from "src/hooks/useConfig";
-import useMasterSha from "src/hooks/useMasterSha";
+import useBaseSha from "src/hooks/useBaseSha";
 import useOwnerRepo from "src/hooks/useOwnerRepo";
 import useProdTag from "src/hooks/useProdTag";
 import Stack from "@mui/material/Stack";
@@ -17,7 +17,7 @@ import Skeleton from "@mui/material/Skeleton";
 export default function Comparison({ repo }: { repo: Repository }) {
   const octokit = useOctokit();
   const ownerRepo = useOwnerRepo();
-  const masterSha = useMasterSha();
+  const baseSha = useBaseSha();
   const prodTag = useProdTag();
   const config = useConfig();
 
@@ -26,7 +26,7 @@ export default function Comparison({ repo }: { repo: Repository }) {
       "getComparison",
       {
         ownerRepo: ownerRepo.data,
-        masterSha: masterSha.data,
+        baseSha: baseSha.data,
         prodSha: prodTag.data?.commit.sha,
       },
     ],
@@ -34,11 +34,10 @@ export default function Comparison({ repo }: { repo: Repository }) {
       getCommitComparison(
         octokit!,
         ownerRepo.data!,
-        masterSha.data!,
+        baseSha.data!,
         prodTag.data!.commit.sha
       ),
-    enabled:
-      !!octokit && !!ownerRepo.data && !!masterSha.data && !!prodTag.data,
+    enabled: !!octokit && !!ownerRepo.data && !!baseSha.data && !!prodTag.data,
     // default branch should not be rewritten, this will not go out of date
     // unless the refs are updated
     staleTime: Infinity,
@@ -79,12 +78,12 @@ export default function Comparison({ repo }: { repo: Repository }) {
 async function getCommitComparison(
   octokit: Octokit,
   ownerRepo: OwnerRepo,
-  masterSha: string,
+  baseSha: string,
   prodSha: string
 ): Promise<CommitComparison> {
   const comparison = await octokit.request(
     "GET /repos/{owner}/{repo}/compare/{basehead}",
-    { ...ownerRepo, basehead: `${prodSha}...${masterSha}` }
+    { ...ownerRepo, basehead: `${prodSha}...${baseSha}` }
   );
   return comparison.data;
 }

--- a/qvet-web/src/hooks/useBaseSha.ts
+++ b/qvet-web/src/hooks/useBaseSha.ts
@@ -6,21 +6,21 @@ import { Config } from "src/utils/config";
 import { useRepo } from "src/hooks/useOwnerRepo";
 import { Repository } from "src/octokitHelpers";
 
-export default function useMasterSha() {
+export default function useBaseSha() {
   const octokit = useOctokit();
   const repo = useRepo();
   const config = useConfig();
 
   return useQuery({
-    queryKey: ["getMasterSha", { ownerRepo: repo.data, config: config.data }],
-    queryFn: () => getMasterSha(octokit!, repo.data!, config.data!),
+    queryKey: ["getBaseSha", { ownerRepo: repo.data, config: config.data }],
+    queryFn: () => getBaseSha(octokit!, repo.data!, config.data!),
     refetchInterval: GIT_REF_POLL_INTERVAL_MS,
     staleTime: GIT_REF_POLL_INTERVAL_MS,
     enabled: !!octokit && !!repo.data && !!config.data,
   });
 }
 
-async function getMasterSha(
+async function getBaseSha(
   octokit: Octokit,
   repo: Repository,
   config: Config,

--- a/qvet-web/src/hooks/useMasterSha.ts
+++ b/qvet-web/src/hooks/useMasterSha.ts
@@ -1,30 +1,34 @@
 import { useQuery } from "@tanstack/react-query";
 import { Octokit } from "octokit";
 import useOctokit from "src/hooks/useOctokit";
+import useConfig from "src/hooks/useConfig";
+import { Config } from "src/utils/config";
 import { useRepo } from "src/hooks/useOwnerRepo";
 import { Repository } from "src/octokitHelpers";
 
 export default function useMasterSha() {
   const octokit = useOctokit();
   const repo = useRepo();
+  const config = useConfig();
 
   return useQuery({
-    queryKey: ["getMasterSha", { ownerRepo: repo.data }],
-    queryFn: () => getMasterSha(octokit!, repo.data!),
+    queryKey: ["getMasterSha", { ownerRepo: repo.data, config: config.data }],
+    queryFn: () => getMasterSha(octokit!, repo.data!, config.data!),
     refetchInterval: GIT_REF_POLL_INTERVAL_MS,
     staleTime: GIT_REF_POLL_INTERVAL_MS,
-    enabled: !!octokit && !!repo.data,
+    enabled: !!octokit && !!repo.data && !!config.data,
   });
 }
 
 async function getMasterSha(
   octokit: Octokit,
-  repo: Repository
+  repo: Repository,
+  config: Config,
 ): Promise<string> {
   const branch = await octokit.rest.repos.getBranch({
     owner: repo.owner.login,
     repo: repo.name,
-    branch: "master",
+    branch: config.commit.base ? config.commit.base : repo.default_branch,
   });
   return branch.data.commit.sha;
 }

--- a/qvet-web/src/utils/config.ts
+++ b/qvet-web/src/utils/config.ts
@@ -27,6 +27,7 @@ const SCHEMA_COMMIT = {
   type: "object",
   properties: {
     ignore: SCHEMA_COMMIT_IGNORE,
+    base: { type: "string", minLength: 1, maxLength: 128 },
   },
   required: [],
   additionalProperties: false,
@@ -114,6 +115,7 @@ export interface Config {
       authors: Array<string>;
       merges: boolean;
     };
+    base: string | null;
   };
   release: {
     identifiers: Array<Identifier>;
@@ -166,6 +168,7 @@ function standardiseConfig(raw: any): Config {
         authors: raw.commit?.ignore?.authors ?? [],
         merges: raw.commit?.ignore?.merges ?? false,
       },
+      base: raw.commit?.base ?? null,
     },
     release: {
       identifiers: raw.release?.identifiers ?? [


### PR DESCRIPTION
This makes the "default" branch qvet works against configurable, dubbed `base_branch`. 

Currently it was assuming the github default branch or hard-coded to "master". While making it all the default branch would've probably been enough, this adds that extra configurability of being able to be explicit. Defaults to github "default" branch if unset.

The `qvet.yml` itself is always loaded from the github default branch as otherwise we'd have to configure the base branch outside the config.