### PR TITLE
web: fix not setting embargo description

### DIFF
--- a/qvet-web/src/components/AddEmbargoDialog.tsx
+++ b/qvet-web/src/components/AddEmbargoDialog.tsx
@@ -29,11 +29,10 @@ export default function AddEmbargoDialog(
   const [message, setMessage] = useState<string>("");
 
   const id = randomHexId();
-  const [remove, setRemove] = useSetCommitState(
+  const addEmbargo = useSetCommitState(
     sha,
     "failure",
     `${STATUS_CONTEXT_EMBARGO_PREFIX}${id}`,
-    message,
   );
 
   const inputGroupRef = useRef<HTMLElement>(null);
@@ -49,7 +48,7 @@ export default function AddEmbargoDialog(
   };
 
   const handleOk = () => {
-    setRemove();
+    addEmbargo.mutate({ description: message });
     onClose();
     setMessage("");
   };
@@ -93,7 +92,7 @@ export default function AddEmbargoDialog(
         <LoadingButton
           type="submit"
           variant="contained"
-          loading={remove.isLoading}
+          loading={addEmbargo.isLoading}
           onClick={handleOk}>
           Embargo
         </LoadingButton>

--- a/qvet-web/src/components/CommitRow.tsx
+++ b/qvet-web/src/components/CommitRow.tsx
@@ -7,6 +7,7 @@ import Skeleton from "@mui/material/Skeleton";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
 import { grey } from "@mui/material/colors";
+import { useCallback } from "react";
 
 import DisplayState from "src/components/DisplayState";
 import ShaLink from "src/components/ShaLink";
@@ -24,16 +25,17 @@ export default function CommitRow({
   const sha = commit.sha;
   const status = useCommitStatus(sha, STATUS_CONTEXT_QA);
 
-  const [approve, setApprove] = useSetCommitState(
-    sha,
-    "success",
-    STATUS_CONTEXT_QA,
+  const approve = useSetCommitState(sha, "success", STATUS_CONTEXT_QA);
+  const deny = useSetCommitState(sha, "failure", STATUS_CONTEXT_QA);
+  const clear = useSetCommitState(sha, "pending", STATUS_CONTEXT_QA);
+  const setApprove = useCallback(
+    () => approve.mutate({ description: null }),
+    [approve],
   );
-  const [deny, setDeny] = useSetCommitState(sha, "failure", STATUS_CONTEXT_QA);
-  const [clear, setClear] = useSetCommitState(
-    sha,
-    "pending",
-    STATUS_CONTEXT_QA,
+  const setDeny = useCallback(() => deny.mutate({ description: null }), [deny]);
+  const setClear = useCallback(
+    () => clear.mutate({ description: null }),
+    [clear],
   );
 
   return (

--- a/qvet-web/src/components/DeploymentHeadline.tsx
+++ b/qvet-web/src/components/DeploymentHeadline.tsx
@@ -50,10 +50,14 @@ interface EmbargoRowProps {
 }
 
 function EmbargoRow({ sha, status, id }: EmbargoRowProps) {
-  const [remove, setRemove] = useSetCommitState(
+  const remove = useSetCommitState(
     sha,
     "success",
     `${STATUS_CONTEXT_EMBARGO_PREFIX}${id}`,
+  );
+  const setRemove = useCallback(
+    () => remove.mutate({ description: null }),
+    [remove],
   );
   const action = (
     <Stack style={{ height: "100%" }} spacing={1} justifyContent="center">

--- a/qvet-web/src/hooks/useSetCommitState.ts
+++ b/qvet-web/src/hooks/useSetCommitState.ts
@@ -11,19 +11,22 @@ import { Status } from "src/octokitHelpers";
 import { setCommitStatus } from "src/queries";
 import { WriteableState } from "src/utils/status";
 
+interface Variables {
+  description: string | null;
+}
+
 export default function useSetCommitState(
   sha: string,
   state: WriteableState,
   context: string,
-  description: string | null = null,
-): [UseMutationResult<unknown, unknown, void>, () => void] {
+): UseMutationResult<unknown, unknown, Variables> {
   const octokit = useOctokit();
   const login = useLogin();
   const ownerRepo = useOwnerRepo();
 
   const queryClient = useQueryClient();
-  const setCommitState = useMutation({
-    mutationFn: async () => {
+  return useMutation({
+    mutationFn: async ({ description }: Variables) => {
       if (!login.data || !octokit || !ownerRepo.data) {
         return;
       }
@@ -57,6 +60,4 @@ export default function useSetCommitState(
       }
     },
   });
-
-  return [setCommitState, () => setCommitState.mutate()];
 }


### PR DESCRIPTION
Bug was caused by the dialogue closing and setting the message to `""` before the request to store the embargo to api fired.

This PR reworks the `useSetCommitState` hook to take advantage of [`useMutation`'s `TVariables`](https://tanstack.com/query/v4/docs/react/reference/useMutation) rather than passing the description in to the initial hook.

This seems like a better way all round, it would probably be good to see if the other stored data can be refactored in the same way, but not for now!