### PR TITLE
chore: ipv6-related readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Start the two services in development/hot reload mode. Respectively:
 - `web` with `cd qvet-web && npm install && npm run dev`
 - `api` with `cd qvet-api && cargo watch -x 'run -- --bind 0.0.0.0:3000'`
 
+*NOTE*
+
+You'll need to make sure that `http://localhost` is mapped to an IPv4 address.
+If it isn't, then the webapp won't be able to resolve the API correctly.
+
+Check `/etc/hosts` for any keys that map to `localhost`.
+
 ## Standalone deployment
 
 For convenience, `qvet` can run bundled in a single binary.


### PR DESCRIPTION
Ran into an issue where a localhost that is mapped to an IPv6 address will cause problems with webapp. Namely, it won't be able to access the API.

Just adding a note to `README.md` to account for this in the future.