### PR TITLE
feat: tweak the fuzzy search to be less fuzzy

### DIFF
--- a/qvet-web/src/components/CommitSummary.tsx
+++ b/qvet-web/src/components/CommitSummary.tsx
@@ -166,6 +166,8 @@ const useFuzzySearch = (list: Array<Commit>, search: string) => {
       // We don't want sorting here as it will mess up the order (since it will
       // order by closest match first)
       shouldSort: false,
+      threshold: 0.3,
+      distance: 30,
     });
   }, [list]);
 


### PR DESCRIPTION
It turns out that for the use-case of searching for names, the defaults that come with Fuse.JS are a little bit _too_ loose. Therefore, this tightens them up a bit by decreasing the threshold and distance as outlined here:

    https://www.fusejs.io/api/options.html#fuzzy-matching-options

This reduces them down significantly, but I think that should be better for match on exact names when the user clicks on the appropriate button.