### PR TITLE
fix(web): actually inform user that they can deploy

### DIFF
--- a/qvet-web/.eslintrc.cjs
+++ b/qvet-web/.eslintrc.cjs
@@ -142,6 +142,7 @@ module.exports = {
     "react/no-children-prop": "error",
     "react/no-find-dom-node": "error",
     "use-isnan": "error",
+    curly: "error",
 
     // Disabled
     "@typescript-eslint/no-explicit-any": "off",

--- a/qvet-web/src/components/DeploymentHeadline.tsx
+++ b/qvet-web/src/components/DeploymentHeadline.tsx
@@ -110,8 +110,9 @@ interface DeploymentUsersProps {
 const DeploymentUsers = memo(function ({ commits }: DeploymentUsersProps) {
   const allUsers = useTeamMembers();
   const loginData = useLogin();
-  if (allUsers.isLoading || allUsers.isError || allUsers.data === null)
+  if (allUsers.isLoading || allUsers.isError || allUsers.data === null) {
     return null;
+  }
 
   const userIdsWithCommits = new Set(
     commits.map((commit) => commit.author?.id).filter((id) => id !== undefined),
@@ -120,16 +121,21 @@ const DeploymentUsers = memo(function ({ commits }: DeploymentUsersProps) {
     (user) => !userIdsWithCommits.has(user.id),
   );
 
-  if (usersWithoutCommits.length === 0)
+  if (usersWithoutCommits.length === 0) {
     return (
       <Typography>
         All team members have a commit to be deployed, please ask the
         support-dev to do an emergency deployment
       </Typography>
     );
+  }
 
-  if (loginData.data && loginData.data.id in usersWithoutCommits)
+  const userIdsWithoutCommits = new Set(
+    usersWithoutCommits.map((user) => user.id),
+  );
+  if (loginData.data && userIdsWithoutCommits.has(loginData.data.id)) {
     return <Typography>You can deploy!</Typography>;
+  }
 
   const luckyUsers = selectUsers(usersWithoutCommits);
   const userSingularOrPlural = luckyUsers.length > 1 ? "users" : "user";


### PR DESCRIPTION
I was checking if the logged in user's id was in a set of objects, which would of course not work. I just need to pull out the ids from the users that do not have commits.