### PR TITLE
feat: add support for github checkruns

### DIFF
--- a/qvet-web/src/components/DeploymentHeadline.tsx
+++ b/qvet-web/src/components/DeploymentHeadline.tsx
@@ -299,28 +299,15 @@ export default function DeploymentHeadline({
   );
 
   if (readyToDeploy) {
-    if (unresolvedCheckRuns) {
-      alerts.push(
-        <Alert
-          key="non-blocking-deploy"
-          severity="info"
-          action={action ? <ReadyAction action={action} /> : null}>
-          Some check runs have not completed successfuly, please consider before
-          deploying.
-          <DeploymentUsers commits={commits} />
-        </Alert>,
-      );
-    } else {
-      alerts.push(
-        <Alert
-          key="ready-to-deploy"
-          severity="success"
-          action={action ? <ReadyAction action={action} /> : null}>
-          Ready to Deploy
-          <DeploymentUsers commits={commits} />
-        </Alert>,
-      );
-    }
+    alerts.push(
+      <Alert
+        key="ready-to-deploy"
+        severity="success"
+        action={action ? <ReadyAction action={action} /> : null}>
+        Ready to Deploy
+        <DeploymentUsers commits={commits} />
+      </Alert>,
+    );
   }
 
   return alerts.length > 0 ? <Stack spacing={1}>{alerts}</Stack> : null;

--- a/qvet-web/src/components/DeploymentHeadline.tsx
+++ b/qvet-web/src/components/DeploymentHeadline.tsx
@@ -10,9 +10,14 @@ import {
   QueriesResults,
 } from "@tanstack/react-query";
 import { memo, useCallback } from "react";
+import { Link } from "react-router-dom";
 
 import RelativeTime from "src/components/RelativeTime";
 import UserLink from "src/components/UserLink";
+import {
+  filterUnresolvedCheckRuns,
+  useCheckRuns,
+} from "src/hooks/useCheckRuns";
 import {
   commitStatusQuery,
   useCommitStatusList,
@@ -26,6 +31,7 @@ import useOwnerRepo from "src/hooks/useOwnerRepo";
 import useSetCommitState from "src/hooks/useSetCommitState";
 import useTeamMembers from "src/hooks/useTeamMembers";
 import { Commit, Status } from "src/octokitHelpers";
+import { CheckRun } from "src/octokitHelpers";
 import {
   STATUS_CONTEXT_QA,
   STATUS_CONTEXT_DEPLOYMENT_NOTE_PREFIX,
@@ -137,6 +143,32 @@ function DeploymentNoteRow({ sha, status, id }: EmbargoRowProps) {
   );
 }
 
+// Alert for a check run that is either incomplete or failed
+function UnresolvedCheckRun({
+  checkRun,
+}: {
+  checkRun: CheckRun;
+}): React.ReactElement {
+  return (
+    <Alert severity="warning">
+      {checkRun.status === "completed" ? (
+        <AlertTitle>
+          {checkRun.name} has completed with status "{checkRun.conclusion}"
+        </AlertTitle>
+      ) : (
+        <AlertTitle>
+          {checkRun.name} is incomplete with status "{checkRun.status}"
+        </AlertTitle>
+      )}
+      {checkRun.details_url && (
+        <Link to={checkRun.details_url} target="_blank" rel="noopener">
+          {checkRun.details_url}
+        </Link>
+      )}
+    </Alert>
+  );
+}
+
 function selectUsers<T>(array: Array<T>) {
   // Optimally randomly select a set of max 3 users
   const finalArraySize = Math.min(array.length, 3);
@@ -221,6 +253,11 @@ export default function DeploymentHeadline({
   const config = useConfig();
   const action = !!config.data && config.data.action.ready;
 
+  const checkRuns = useCheckRuns();
+  const unresolvedCheckRuns = checkRuns.isSuccess
+    ? filterUnresolvedCheckRuns(checkRuns.data)
+    : null;
+
   const alerts = [];
   // Add any embargoes first
   alerts.push(
@@ -246,17 +283,44 @@ export default function DeploymentHeadline({
     )),
   );
 
-  if (readyToDeploy) {
-    const readyAlert = (
-      <Alert
-        key="ready-to-deploy"
-        severity="success"
-        action={action ? <ReadyAction action={action} /> : null}>
-        Ready to Deploy
-        <DeploymentUsers commits={commits} />
-      </Alert>
+  if (checkRuns.isError) {
+    alerts.push(
+      <Alert severity="warning">
+        <AlertTitle>Check runs could not be fetched from GitHub api</AlertTitle>
+      </Alert>,
     );
-    alerts.push(readyAlert);
+  }
+
+  // Then any unsuccessful check runs
+  alerts.push(
+    ...(unresolvedCheckRuns || []).map((checkRun) => (
+      <UnresolvedCheckRun key={checkRun.id} checkRun={checkRun} />
+    )),
+  );
+
+  if (readyToDeploy) {
+    if (unresolvedCheckRuns) {
+      alerts.push(
+        <Alert
+          key="non-blocking-deploy"
+          severity="info"
+          action={action ? <ReadyAction action={action} /> : null}>
+          Some check runs have not completed successfuly, please consider before
+          deploying.
+          <DeploymentUsers commits={commits} />
+        </Alert>,
+      );
+    } else {
+      alerts.push(
+        <Alert
+          key="ready-to-deploy"
+          severity="success"
+          action={action ? <ReadyAction action={action} /> : null}>
+          Ready to Deploy
+          <DeploymentUsers commits={commits} />
+        </Alert>,
+      );
+    }
   }
 
   return alerts.length > 0 ? <Stack spacing={1}>{alerts}</Stack> : null;

--- a/qvet-web/src/hooks/useCheckRuns.ts
+++ b/qvet-web/src/hooks/useCheckRuns.ts
@@ -1,0 +1,85 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { Octokit } from "octokit";
+
+import useAccessToken from "src/hooks/useAccessToken";
+import useOctokit from "src/hooks/useOctokit";
+import { CheckRun, OwnerRepo } from "src/octokitHelpers";
+
+import useBaseSha from "./useBaseSha";
+import useOwnerRepo from "./useOwnerRepo";
+
+/**
+ * Return all checks runs for base SHA
+ *
+ * Will fail if no user is credentialed.
+ */
+export function useCheckRuns(): UseQueryResult<Array<CheckRun>, Error> {
+  const accessToken = useAccessToken();
+  const octokit = useOctokit();
+  const baseSha = useBaseSha();
+  const ownerRepo = useOwnerRepo();
+
+  return useQuery({
+    queryKey: ["getCheckRuns", accessToken.data],
+    queryFn: () => getCheckRuns(octokit!, baseSha.data!, ownerRepo.data!),
+    enabled:
+      !!accessToken.data && !!baseSha.data && !!ownerRepo.data && !!octokit,
+  });
+}
+
+async function getCheckRuns(
+  octokit: Octokit,
+  baseSha: string,
+  ownerRepo: OwnerRepo,
+): Promise<Array<CheckRun>> {
+  const response = await octokit.rest.checks.listForRef({
+    ...ownerRepo,
+    ref: baseSha,
+  });
+  return response.data.check_runs;
+}
+
+// filter for check runs that have not returned success on their latest run
+export const filterUnresolvedCheckRuns = (
+  checkRuns: ReadonlyArray<CheckRun>,
+): ReadonlyArray<CheckRun> => {
+  const latestAttempts = filterLatestAttempts(checkRuns);
+  return latestAttempts.filter((checkRun) => checkRun.conclusion !== "success");
+};
+
+// function dedupes check runs with the same name returning the only the latest
+const filterLatestAttempts = (
+  checkRuns: ReadonlyArray<CheckRun>,
+): ReadonlyArray<CheckRun> => {
+  const byName: Record<string, Array<CheckRun>> = {};
+  for (const checkRun of checkRuns) {
+    if (byName[checkRun.name] === undefined) {
+      byName[checkRun.name] = [];
+    }
+    byName[checkRun.name].push(checkRun);
+  }
+  return Object.values(byName).flatMap((checkRuns) => {
+    let completed: Array<CheckRun> = checkRuns.filter(
+      (checkRun) => checkRun.status === "completed",
+    );
+    let incomplete: Array<CheckRun> = checkRuns.filter(
+      (checkRun) => checkRun.status !== "completed",
+    );
+
+    if (incomplete.length > 0) {
+      incomplete = incomplete.sort(
+        (a, b) =>
+          new Date(b.started_at || 0).getTime() -
+          new Date(a.started_at || 0).getTime(),
+      );
+      return incomplete.slice(0, 1);
+    } else {
+      completed = completed.sort(
+        (a, b) =>
+          new Date(b.completed_at || 0).getTime() -
+          new Date(a.completed_at || 0).getTime(),
+      );
+      return completed.slice(0, 1);
+    }
+  });
+};

--- a/qvet-web/src/octokitHelpers.ts
+++ b/qvet-web/src/octokitHelpers.ts
@@ -13,6 +13,7 @@ export interface Team {
 export type Commit = components["schemas"]["commit"];
 export type CommitComparison = components["schemas"]["commit-comparison"];
 export type Status = components["schemas"]["status"];
+export type CheckRun = components["schemas"]["check-run"];
 export type User = components["schemas"]["simple-user"];
 export type Repository = components["schemas"]["repository"];
 export type Installation = components["schemas"]["installation"];


### PR DESCRIPTION
Adds to qvet github "check runs" for the base commit (the latest commit being compared against prod, if my understanding is correct) -
Check Runs RestApi: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28

To keep qvet a generic solution there is no hard coded logic about which check runs are important. I guess this may be a frustration at somepoint if there are lots of checks runs that constantly fail and we ignore (I do not believe this is currently the case).

Note: my testing was a bit hacky. I got the request authorized and would receive an empty array of check runs in the network tab. I used hardcoded data (curled directly from reinfer/platform) to test scenarios. So I've not properly tested it end-to-end. But I do believe it will work.

![Screenshot from 2024-12-13 17-12-36](https://github.com/user-attachments/assets/e4040a6a-710b-4119-9982-294903d47d0b)

![Screenshot from 2024-12-13 17-10-21](https://github.com/user-attachments/assets/258bf7c4-a1f6-4031-9807-4d73c4291169)

## OAuth Changes 
I had to grant the read access for checks (I granted it for the qvet staging app) for this to be accessible.

![Screenshot from 2024-12-13 15-39-04](https://github.com/user-attachments/assets/faf32f55-f52b-48ef-bc83-bac3bc4e0095)
