### PR TITLE
feat: add support for routine checks

### DIFF
--- a/qvet-web/src/components/CommitSummary.tsx
+++ b/qvet-web/src/components/CommitSummary.tsx
@@ -18,6 +18,7 @@ import useLogin from "src/hooks/useLogin";
 import { Commit, CommitComparison, Repository } from "src/octokitHelpers";
 import { Config } from "src/utils/config";
 
+import RoutineChecks from "./RoutineChecks";
 import UserAvatar from "./UserAvatar";
 
 interface CommitSummaryProps {
@@ -89,6 +90,7 @@ export default function CommitSummary({
   const deploymentHeadline = (
     <DeploymentHeadline
       commits={developerCommits}
+      routineChecks={config.routine_checks}
       baseSha={comparison.base_commit.sha}
     />
   );
@@ -112,7 +114,16 @@ export default function CommitSummary({
           {configStatus}
         </Collapse>
       }
-      <CommitTable commits={visibleCommits} />
+      <CommitTable
+        commits={visibleCommits}
+        showHeader={!!config.routine_checks.length}
+      />
+      {config.routine_checks.length > 0 && (
+        <RoutineChecks
+          checks={config.routine_checks}
+          baseSha={comparison.base_commit.sha}
+        />
+      )}
       <Typography variant="caption">
         Showing {developerCommits.length} undeployed commits on{" "}
         <code>{base_branch}</code> (view the{" "}

--- a/qvet-web/src/components/CommitTable.tsx
+++ b/qvet-web/src/components/CommitTable.tsx
@@ -7,30 +7,37 @@ import TableRow from "@mui/material/TableRow";
 import CommitRow from "src/components/CommitRow";
 import { Commit } from "src/octokitHelpers";
 
+import TableHeader from "./TableHeader";
+
 export default function CommitTable({
   commits: rawCommits,
+  showHeader,
 }: {
   commits: ReadonlyArray<Commit>;
+  showHeader: boolean;
 }): React.ReactElement {
   // FIXME warn/paginate on large numbers
   const commits = rawCommits.slice(0, 100);
 
   return (
-    <Table sx={{ minWidth: 650 }} size="small">
-      <TableHead>
-        <TableRow>
-          <TableCell>Message</TableCell>
-          <TableCell>Author</TableCell>
-          <TableCell>Hash</TableCell>
-          <TableCell>Manual QA</TableCell>
-          <TableCell>Actions</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {commits.map((commit) => (
-          <CommitRow key={commit.sha} commit={commit} />
-        ))}
-      </TableBody>
-    </Table>
+    <>
+      {showHeader && <TableHeader title="Commits" />}
+      <Table sx={{ minWidth: 650 }} size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Message</TableCell>
+            <TableCell>Author</TableCell>
+            <TableCell>Hash</TableCell>
+            <TableCell>Manual QA</TableCell>
+            <TableCell>Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {commits.map((commit) => (
+            <CommitRow key={commit.sha} commit={commit} />
+          ))}
+        </TableBody>
+      </Table>
+    </>
   );
 }

--- a/qvet-web/src/components/DeploymentHeadline.tsx
+++ b/qvet-web/src/components/DeploymentHeadline.tsx
@@ -28,6 +28,7 @@ import useConfig from "src/hooks/useConfig";
 import useLogin from "src/hooks/useLogin";
 import useOctokit from "src/hooks/useOctokit";
 import useOwnerRepo from "src/hooks/useOwnerRepo";
+import useRoutineChecksComplete from "src/hooks/useRoutineChecksComplete";
 import useSetCommitState from "src/hooks/useSetCommitState";
 import useTeamMembers from "src/hooks/useTeamMembers";
 import { Commit, Status } from "src/octokitHelpers";
@@ -37,7 +38,7 @@ import {
   STATUS_CONTEXT_DEPLOYMENT_NOTE_PREFIX,
   STATUS_CONTEXT_EMBARGO_PREFIX,
 } from "src/queries";
-import { Action } from "src/utils/config";
+import { Action, RoutineCheck } from "src/utils/config";
 
 function useAllQaSuccess(commits: Array<Commit>): boolean {
   const octokit = useOctokit();
@@ -235,11 +236,17 @@ const DeploymentUsers = memo(function ({ commits }: DeploymentUsersProps) {
 export default function DeploymentHeadline({
   commits,
   baseSha,
+  routineChecks,
 }: {
   commits: Array<Commit>;
   baseSha: string;
+  routineChecks: ReadonlyArray<RoutineCheck>;
 }): React.ReactElement | null {
   const commitStatusList = useCommitStatusList(baseSha);
+  const routineChecksComplete = useRoutineChecksComplete(
+    baseSha,
+    routineChecks,
+  );
   const embargoList = commitStatusList.isSuccess
     ? embargoListFromStatusList(baseSha, commitStatusList.data)
     : null;
@@ -249,7 +256,8 @@ export default function DeploymentHeadline({
 
   const noEmbargos = embargoList !== null && embargoList.length === 0;
   const allQaSuccess = useAllQaSuccess(commits);
-  const readyToDeploy = noEmbargos && allQaSuccess && commits.length > 0;
+  const readyToDeploy =
+    noEmbargos && allQaSuccess && commits.length > 0 && routineChecksComplete;
   const config = useConfig();
   const action = !!config.data && config.data.action.ready;
 

--- a/qvet-web/src/components/RoutineChecks.tsx
+++ b/qvet-web/src/components/RoutineChecks.tsx
@@ -1,0 +1,141 @@
+import CloseIcon from "@mui/icons-material/Close";
+import DoneIcon from "@mui/icons-material/Done";
+import ReplayIcon from "@mui/icons-material/Replay";
+import LoadingButton from "@mui/lab/LoadingButton";
+import { Table, TableHead } from "@mui/material";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import Skeleton from "@mui/material/Skeleton";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import { grey } from "@mui/material/colors";
+import React from "react";
+import { Link } from "react-router-dom";
+
+import useCommitStatus from "src/hooks/useCommitStatus";
+import useSetCommitState from "src/hooks/useSetCommitState";
+import { STATUS_CONTEXT_ROUTINE_CHECK_PREFIX } from "src/queries";
+import { RoutineCheck } from "src/utils/config";
+
+import DisplayState from "./DisplayState";
+import TableHeader from "./TableHeader";
+
+export const routineCheckContext = (check: RoutineCheck): string =>
+  `${STATUS_CONTEXT_ROUTINE_CHECK_PREFIX}${check.id}`;
+
+export default function RoutineChecks({
+  baseSha,
+  checks,
+}: {
+  baseSha: string;
+  checks: ReadonlyArray<RoutineCheck>;
+}): React.ReactElement {
+  return (
+    <>
+      <TableHeader title="Routine Checks" />
+      <Table
+        sx={{
+          width: "100%",
+        }}
+        size="small">
+        <colgroup>
+          <col style={{ width: "auto" }} />
+          <col style={{ width: "22%" }} />
+          <col style={{ width: "10%" }} />
+        </colgroup>
+        <TableHead>
+          <TableRow>
+            <TableCell>Check</TableCell>
+            <TableCell>Manual QA</TableCell>
+            <TableCell>Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        {checks.map((check) => (
+          <RoutineCheckRow key={check.id} sha={baseSha} check={check} />
+        ))}
+      </Table>
+    </>
+  );
+}
+
+function RoutineCheckRow({
+  sha,
+  check,
+}: {
+  sha: string;
+  check: RoutineCheck;
+}): React.ReactElement {
+  const context = routineCheckContext(check);
+  const commitStatus = useCommitStatus(sha, context);
+
+  const approve = useSetCommitState(sha, "success", context);
+  const deny = useSetCommitState(sha, "failure", context);
+  const reset = useSetCommitState(sha, "pending", context);
+
+  return (
+    <TableRow>
+      <TableCell
+        component="th"
+        scope="row"
+        style={{
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          width: "500px",
+        }}>
+        {check.text}
+        {check.url && (
+          <>
+            <br />
+            <Link to={check.url} target="_blank" rel="noopener">
+              More details.
+            </Link>
+          </>
+        )}
+      </TableCell>
+      <TableCell align="right">
+        {commitStatus.isLoading ? (
+          <DisplayStateSkeleton animation={false} />
+        ) : (
+          <DisplayState status={commitStatus.data!} />
+        )}
+      </TableCell>
+      <TableCell align="right" width="0px">
+        <ButtonGroup>
+          <LoadingButton
+            title="Mark QA as Completed"
+            onClick={() =>
+              approve.mutate({ description: "Routine check approved" })
+            }
+            loading={approve.isLoading}>
+            <DoneIcon />
+          </LoadingButton>
+          <LoadingButton
+            title="Mark QA as Rejected"
+            onClick={() => deny.mutate({ description: "Routine check failed" })}
+            loading={deny.isLoading}>
+            <CloseIcon />
+          </LoadingButton>
+          <LoadingButton
+            title="Reset QA Status"
+            style={{ color: grey[400] }}
+            onClick={() => reset.mutate({ description: "Routine check reset" })}
+            loading={reset.isLoading}>
+            <ReplayIcon />
+          </LoadingButton>
+        </ButtonGroup>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function DisplayStateSkeleton({ ...rest }) {
+  return (
+    <Skeleton
+      animation="wave"
+      variant="text"
+      width={84}
+      height={20}
+      {...rest}
+    />
+  );
+}

--- a/qvet-web/src/components/TableHeader.tsx
+++ b/qvet-web/src/components/TableHeader.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from "@mui/material";
+
+export default function TableHeader({
+  title,
+}: {
+  title: string;
+}): React.ReactElement {
+  return (
+    <Box
+      sx={{
+        padding: "10px",
+        borderBottom: (theme) =>
+          `1px solid ${theme.palette.getContrastText(
+            theme.palette.background.paper,
+          )}`,
+      }}>
+      <Typography variant="body1">{title}</Typography>
+    </Box>
+  );
+}

--- a/qvet-web/src/hooks/useRoutineChecksComplete.ts
+++ b/qvet-web/src/hooks/useRoutineChecksComplete.ts
@@ -1,0 +1,29 @@
+import { routineCheckContext } from "src/components/RoutineChecks";
+import { RoutineCheck } from "src/utils/config";
+
+import { useCommitStatuses } from "./useCommitStatus";
+
+export default function useRoutineChecksComplete(
+  sha: string,
+  checks: ReadonlyArray<RoutineCheck>,
+): boolean {
+  const rountineCheckStatusQueries = useCommitStatuses(
+    sha,
+    checks.map(routineCheckContext),
+  );
+
+  for (const query of rountineCheckStatusQueries) {
+    if (query.isLoading) {
+      return false;
+    }
+  }
+  for (const query of rountineCheckStatusQueries) {
+    if (query.isError) {
+      // if any responses have errored assume checks are complete, to not block
+      return true;
+    }
+  }
+  return rountineCheckStatusQueries.every(
+    (query) => query.data?.state === "success",
+  );
+}

--- a/qvet-web/src/octokitHelpers.ts
+++ b/qvet-web/src/octokitHelpers.ts
@@ -1,4 +1,4 @@
-import { components } from "@octokit/openapi-types";
+import { components, paths } from "@octokit/openapi-types";
 
 export interface OwnerRepo {
   owner: string;
@@ -18,3 +18,6 @@ export type User = components["schemas"]["simple-user"];
 export type Repository = components["schemas"]["repository"];
 export type Installation = components["schemas"]["installation"];
 export type Ref = components["schemas"]["git-ref"];
+
+export type UpdateStatus =
+  paths["/repos/{owner}/{repo}/statuses/{sha}"]["post"]["requestBody"];

--- a/qvet-web/src/queries/index.ts
+++ b/qvet-web/src/queries/index.ts
@@ -4,6 +4,8 @@ import { Octokit } from "octokit";
 import { OwnerRepo, Status, User, Team } from "src/octokitHelpers";
 import { UpdateState, stateDisplay } from "src/utils/status";
 
+export const STATUS_CONTEXT_ROUTINE_CHECK_PREFIX = "qvet/routine-check/";
+export const STATUS_CONTEXT_ROUTINE_CHECK_OWNERS = "qvet/routine-check/owners";
 export const STATUS_CONTEXT_EMBARGO_PREFIX = "qvet/embargo/";
 export const STATUS_CONTEXT_DEPLOYMENT_NOTE_PREFIX = "qvet/note/";
 export const STATUS_CONTEXT_QA = "qvet/qa";

--- a/qvet-web/src/utils/config.ts
+++ b/qvet-web/src/utils/config.ts
@@ -94,6 +94,22 @@ const SCHEMA_TEAM = {
   additionalProperties: false,
 };
 
+const SCHEMA_ROUTINE_CHECK = {
+  type: "object",
+  properties: {
+    id: { type: "string", maxLength: 36 },
+    text: { type: "string", maxLength: 256 },
+    url: { type: "string", maxLength: 256 },
+  },
+  required: ["id", "text"],
+  additionalProperties: false,
+};
+
+const SCHEMA_ROUTINE_CHECKS = {
+  type: "array",
+  items: SCHEMA_ROUTINE_CHECK,
+};
+
 const SCHEMA = {
   type: "object",
   properties: {
@@ -101,6 +117,7 @@ const SCHEMA = {
     commit: SCHEMA_COMMIT,
     release: SCHEMA_RELEASE,
     team: SCHEMA_TEAM,
+    routine_checks: SCHEMA_ROUTINE_CHECKS,
   },
   required: [],
   additionalProperties: false,
@@ -121,6 +138,7 @@ export interface Config {
     identifiers: Array<Identifier>;
   };
   team: Team | null;
+  routine_checks: Array<RoutineCheck>;
 }
 
 export interface ActionLink {
@@ -144,6 +162,12 @@ export type Identifier = IdentifierTag;
 export interface ParseConfigFileResult {
   config: Config;
   errorsText: string | null;
+}
+
+export interface RoutineCheck {
+  id: string;
+  text: string;
+  url?: string;
 }
 
 export function parseConfigFile(configFile: string): ParseConfigFileResult {
@@ -178,5 +202,6 @@ function standardiseConfig(raw: any): Config {
       ],
     },
     team: raw.team ?? null,
+    routine_checks: raw.routine_checks ?? [],
   };
 }


### PR DESCRIPTION
Adds "routine checks" to qvet - 
These must all be approved for deployment to be ready

![Screenshot from 2024-12-18 15-08-52](https://github.com/user-attachments/assets/7a72f107-6386-4b0c-91ef-3dd6e0ce7ebc)
![Screenshot from 2024-12-18 15-08-46](https://github.com/user-attachments/assets/5cb6cd18-fa3d-4c4d-902d-a570d6be7797)

These are specified in config: https://github.com/qvet/staging-target/commit/38dcffdbc0559672b15acd4d322a0048edf0d40b

Note: we wanted to have checks randomly assigned to "owners" to ensure that they are completed - this is actually more complicated than I anticipated (having owners that persist - I guess we would have to store it as commit statuses as that's what we have available?). Have left it out of this PR.

