### PR TITLE
feat: external config for github check runs

### DIFF
--- a/qvet-web/src/components/UnresolvedCheckRun.tsx
+++ b/qvet-web/src/components/UnresolvedCheckRun.tsx
@@ -1,0 +1,162 @@
+import { LoadingButton } from "@mui/lab";
+import { Alert, AlertTitle, Stack } from "@mui/material";
+import { Link } from "react-router-dom";
+
+import useBaseSha from "src/hooks/useBaseSha";
+import {
+  checkRunOverruleContext,
+  getCheckRunLevel,
+} from "src/hooks/useCheckRuns";
+import useCommitStatus from "src/hooks/useCommitStatus";
+import useSetCommitState from "src/hooks/useSetCommitState";
+import { CheckRun } from "src/octokitHelpers";
+import { CheckRunGlobalConfig } from "src/utils/config";
+
+import UserLink from "./UserLink";
+
+// Alert for a check run that is either incomplete or failed
+export default function UnresolvedCheckRun({
+  checkRun,
+  config,
+}: {
+  checkRun: CheckRun;
+  config: CheckRunGlobalConfig;
+}): React.ReactElement {
+  const baseSha = useBaseSha();
+  const level = getCheckRunLevel(checkRun, config);
+
+  switch (level) {
+    case "info":
+      return <InfoCheckRun checkRun={checkRun} />;
+    case "embargo":
+      if (baseSha.data) {
+        return <EmbargoCheckRun checkRun={checkRun} sha={baseSha.data} />;
+      }
+      return <></>;
+    case "hidden":
+      return <></>;
+    default:
+      console.error(`Unknown embargo level ${level}`);
+      return <></>;
+  }
+}
+
+function InfoCheckRun({
+  checkRun,
+}: {
+  checkRun: CheckRun;
+}): React.ReactElement {
+  const checkRunName = (
+    <span style={{ fontWeight: "bold" }}>
+      {checkRun.details_url ? (
+        <Link to={checkRun.details_url} target="_blank" rel="noopener">
+          {checkRun.name}
+        </Link>
+      ) : (
+        checkRun.name
+      )}
+    </span>
+  );
+
+  return (
+    <Alert severity="info">
+      {checkRun.status === "completed" ? (
+        <AlertTitle>
+          External job {checkRunName} has completed with status "
+          {checkRun.conclusion}"
+        </AlertTitle>
+      ) : (
+        <AlertTitle>
+          External job {checkRunName} is incomplete with status "
+          {checkRun.status}"
+        </AlertTitle>
+      )}
+      This job does not block deployment. Re-run this job successfully to
+      resolve this issue.
+      <br />
+      <Link to={checkRun.url} target="_blank" rel="noopener">
+        What is this job?
+      </Link>
+    </Alert>
+  );
+}
+
+function EmbargoCheckRun({
+  checkRun,
+  sha,
+}: {
+  checkRun: CheckRun;
+  sha: string;
+}): React.ReactElement {
+  const context = checkRunOverruleContext(checkRun);
+  const commitStatus = useCommitStatus(sha, context);
+
+  const overrule = useSetCommitState(sha, "success", context);
+  const removeOverrule = useSetCommitState(sha, "failure", context);
+
+  const embargoActive = commitStatus.data?.state !== "success";
+
+  const action = (
+    <Stack style={{ height: "100%" }} spacing={1} justifyContent="center">
+      <LoadingButton
+        color="inherit"
+        size="small"
+        onClick={() =>
+          embargoActive
+            ? overrule.mutateAsync({
+                description: "Overruled by user.",
+              })
+            : removeOverrule.mutateAsync({
+                description: "Overrule removed by user.",
+              })
+        }
+        loading={false}>
+        {embargoActive ? "Overrule" : "Remove Overrule"}
+      </LoadingButton>
+    </Stack>
+  );
+  const checkRunName = (
+    <span style={{ fontWeight: "bold" }}>
+      {checkRun.details_url ? (
+        <Link to={checkRun.details_url} target="_blank" rel="noopener">
+          {checkRun.name}
+        </Link>
+      ) : (
+        checkRun.name
+      )}
+    </span>
+  );
+  const userLink = commitStatus.data?.creator ? (
+    <UserLink user={commitStatus.data.creator} inline />
+  ) : null;
+  return (
+    <Alert severity={embargoActive ? "warning" : "info"} action={action}>
+      {checkRun.status === "completed" ? (
+        <AlertTitle>
+          External job {checkRunName} has completed with status "
+          {checkRun.conclusion}"
+        </AlertTitle>
+      ) : (
+        <AlertTitle>
+          External job {checkRunName} is incomplete with status "
+          {checkRun.status}"
+        </AlertTitle>
+      )}
+      {embargoActive ? (
+        <span>
+          This is blocking deployment. Re-run this job successfully to resolve
+          this issue.
+        </span>
+      ) : (
+        <span>
+          This is no longer blocking deployment.{" "}
+          {userLink && <span>Overruled by {userLink}.</span>}
+        </span>
+      )}
+      <br />
+      <Link to={checkRun.url} target="_blank" rel="noopener">
+        What is this job?
+      </Link>
+    </Alert>
+  );
+}

--- a/qvet-web/src/hooks/useCommitStatus.ts
+++ b/qvet-web/src/hooks/useCommitStatus.ts
@@ -92,19 +92,20 @@ export function deploymentNoteListFromStatusList(
   return notes;
 }
 
+// query remains disabled if sha is undefined
 export function useCommitStatusList(
-  sha: string,
+  sha?: string,
 ): UseQueryResult<Array<Status>> {
   const octokit = useOctokit();
   const ownerRepo = useOwnerRepo();
   return useQuery({
     queryKey: ["getCommitStatusList", { ownerRepo: ownerRepo.data, sha }],
     queryFn: async (): Promise<Array<Status>> => {
-      return getCommitStatusList(octokit!, ownerRepo.data!, sha);
+      return getCommitStatusList(octokit!, ownerRepo.data!, sha!);
     },
     refetchInterval: COMMIT_STATUS_POLL_INTERVAL_MS,
     staleTime: COMMIT_STATUS_STALE_TIME_MS,
-    enabled: !!octokit && !!ownerRepo.data,
+    enabled: !!octokit && !!ownerRepo.data && !!sha,
   });
 }
 

--- a/qvet-web/src/queries/index.ts
+++ b/qvet-web/src/queries/index.ts
@@ -7,6 +7,7 @@ import { UpdateState, stateDisplay } from "src/utils/status";
 export const STATUS_CONTEXT_ROUTINE_CHECK_PREFIX = "qvet/routine-check/";
 export const STATUS_CONTEXT_ROUTINE_CHECK_OWNERS = "qvet/routine-check/owners";
 export const STATUS_CONTEXT_EMBARGO_PREFIX = "qvet/embargo/";
+export const STATUS_CONTEXT_CHECK_RUN_EMBARGO_PREFIX = "qvet/check-run/embargo";
 export const STATUS_CONTEXT_DEPLOYMENT_NOTE_PREFIX = "qvet/note/";
 export const STATUS_CONTEXT_QA = "qvet/qa";
 


### PR DESCRIPTION
I think this is actually quite a cool feature now!

Adds external config for check runs: https://github.com/qvet/staging-target/blob/63fa6d672d5fcc18c0b538ddc4a4fde9a17eaf99/qvet.yml#L29-L44

Check runs exist at three levels:
- hidden
- info
- embargo
Note: we will default check runs to "hidden" and then set a couple to level "embargo" i.e. `Platform Promote` and `Platform Deploy [alpha-kf]`. But it's a generic so another product could chose to do the inverse.

If a check run is at "embargo" level it can be overruled - and the overrule can be removed etc (using commit statuses)

![Screenshot from 2024-12-20 10-20-55](https://github.com/user-attachments/assets/748038d2-248c-45dc-8a1b-fbe2c78fcb8c)
![Screenshot from 2024-12-20 10-20-50](https://github.com/user-attachments/assets/4f7de831-d03a-4de4-9733-b925f286861a)

