### PR TITLE
dev(web): remember state of repo and search in url

### DIFF
--- a/qvet-web/package-lock.json
+++ b/qvet-web/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.0",
+        "use-query-params": "^2.2.1",
         "yaml": "^2.2.1",
         "zustand": "^4.3.6"
       },
@@ -5908,6 +5909,12 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/serialize-query-params": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
+      "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==",
+      "license": "ISC"
+    },
     "node_modules/set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -6455,6 +6462,29 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-query-params": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.2.1.tgz",
+      "integrity": "sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==",
+      "license": "ISC",
+      "dependencies": {
+        "serialize-query-params": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@reach/router": "^1.2.1",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-router-dom": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@reach/router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/qvet-web/package.json
+++ b/qvet-web/package.json
@@ -37,6 +37,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0",
+    "use-query-params": "^2.2.1",
     "yaml": "^2.2.1",
     "zustand": "^4.3.6"
   },
@@ -56,5 +57,6 @@
     "eslint-plugin-sonarjs": "^0.19.0",
     "typescript": "^4.9.3",
     "vite": "^4.1.0-beta.1"
-  }
+  },
+  "packageManager": "yarn@4.8.1+sha512.bc946f2a022d7a1a38adfc15b36a66a3807a67629789496c3714dd1703d2e6c6b1c69ff9ec3b43141ac7a1dd853b7685638eb0074300386a59c18df351ef8ff6"
 }

--- a/qvet-web/src/components/CommitSummary.tsx
+++ b/qvet-web/src/components/CommitSummary.tsx
@@ -8,6 +8,7 @@ import Typography from "@mui/material/Typography";
 import Fuse from "fuse.js";
 import { useState, useCallback, useMemo } from "react";
 import { Link } from "react-router-dom";
+import { useQueryParam, StringParam } from "use-query-params";
 
 import AddDeploymentNoteDialog from "src/components/AddDeploymentNoteDialog";
 import AddEmbargoDialog from "src/components/AddEmbargoDialog";
@@ -33,7 +34,20 @@ export default function CommitSummary({
   repo,
 }: CommitSummaryProps): React.ReactElement {
   const [expand, setExpand] = useState<boolean>(false);
-  const [search, setSearch] = useState<string>("");
+  const [searchUrl, setSearchUrl] = useQueryParam(`q`, StringParam);
+  const [search, setSearchStore] = useState<string>(searchUrl ?? "");
+  const setSearch = useCallback(
+    (value: string) => {
+      setSearchStore(value);
+      if (value) {
+        setSearchUrl(value);
+      } else {
+        // Do not set query param if search string empty
+        setSearchUrl(undefined);
+      }
+    },
+    [setSearchStore, setSearchUrl],
+  );
 
   const authorLogins = config.commit.ignore.authors;
   const merges = config.commit.ignore.merges;
@@ -219,7 +233,7 @@ const CommitFiltering = ({
   setSearch,
 }: {
   readonly search: string;
-  readonly setSearch: React.Dispatch<React.SetStateAction<string>>;
+  readonly setSearch: (value: string) => void;
 }) => {
   const loginData = useLogin();
 

--- a/qvet-web/src/components/Installations.tsx
+++ b/qvet-web/src/components/Installations.tsx
@@ -12,7 +12,7 @@ import { useRepo } from "src/hooks/useOwnerRepo";
 export default function Installations(): React.ReactElement {
   const repo = useRepo();
 
-  return repo.isError ? (
+  const content = repo.isError ? (
     <Paper elevation={3}>
       <Box padding={2}>
         <Alert severity="error">Error loading repositories</Alert>
@@ -24,19 +24,23 @@ export default function Installations(): React.ReactElement {
     <Paper elevation={3}>
       <Box padding={2}>
         <Alert severity="info">
-          <AlertTitle>No repositories found</AlertTitle>
+          <AlertTitle>Repository not found</AlertTitle>
           You need to install the{" "}
           <Link target="_blank" to="https://github.com/apps/qvet">
             qvet GitHub App
           </Link>{" "}
-          on a repository before it is listed here.
+          on a repository before it is listed above.
         </Alert>
       </Box>
     </Paper>
   ) : (
+    <Comparison repo={repo.data} />
+  );
+
+  return (
     <>
       <RepoSelect />
-      <Comparison repo={repo.data} />
+      {content}
     </>
   );
 }

--- a/qvet-web/src/main.tsx
+++ b/qvet-web/src/main.tsx
@@ -3,7 +3,9 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { QueryParamProvider } from "use-query-params";
+import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import Shell from "src/components/Shell";
 import Theme from "src/components/Theme";
@@ -14,28 +16,29 @@ const queryClient = new QueryClient();
 
 function App() {
   removeUnusedLocalStorageItems();
-  const router = createBrowserRouter([
-    {
-      path: "/",
-      element: (
-        <Shell>
-          <Home />
-        </Shell>
-      ),
-    },
-    {
-      path: "/oauth2/callback",
-      element: <Oauth2Callback />,
-    },
-  ]);
+  const router = (
+    <BrowserRouter>
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <Shell>
+                <Home />
+              </Shell>
+            }
+          />
+          <Route path="/oauth2/callback" element={<Oauth2Callback />} />
+        </Routes>
+      </QueryParamProvider>
+    </BrowserRouter>
+  );
 
   return (
     <Theme>
       <CssBaseline>
         <QueryClientProvider client={queryClient}>
-          <React.StrictMode>
-            <RouterProvider router={router} />
-          </React.StrictMode>
+          <React.StrictMode>{router}</React.StrictMode>
         </QueryClientProvider>
       </CssBaseline>
     </Theme>


### PR DESCRIPTION
Link up two features to url state:
- Query string in commit search
- Repo selector
  - This required some small refactoring to account for the state where an invalid repo id is given

![image](https://github.com/user-attachments/assets/8072ae21-aa4a-4c44-a900-42e4b1ca2fd0)
